### PR TITLE
fix: typos

### DIFF
--- a/docs/plugins/modules/common.mdx
+++ b/docs/plugins/modules/common.mdx
@@ -496,14 +496,14 @@ Functions:
 
 ### `i18n`
 
-<!-- [!]: `Messages` and all props/functions starting with an underscore aren't documented -->
+<!-- [!]: `Message` and all props/functions starting with an underscore aren't documented -->
 
 Props:
 
-| Name          | Type                       | Description                                  |
-| ------------- | -------------------------- | -------------------------------------------- |
-| `loadPromise` | Promise<void\>             | Promise of when messages got fetched         |
-| `Messages`    | Record<string, `Messages`> | Contains all strings for the selected locale |
+| Name          | Type                      | Description                                  |
+| ------------- | ------------------------- | -------------------------------------------- |
+| `loadPromise` | Promise<void\>            | Promise of when messages got fetched         |
+| `Messages`    | Record<string, `Message`> | Contains all strings for the selected locale |
 
 Functions:
 

--- a/docs/plugins/modules/components.mdx
+++ b/docs/plugins/modules/components.mdx
@@ -128,7 +128,7 @@ Props:
 | `value`                     | string                                                          |                      | Selected radio value                   |
 | `withTransparentBackground` | boolean                                                         | `false`              | Whether the radio group is transparent |
 
-#### Types {Radio-types}
+#### Types {#Radio-types}
 
 ##### `RadioOptionType` {#RadioOptionType}
 
@@ -202,7 +202,7 @@ Props:
 | `serialize`         | (e: string) => void                                    |          | Function ran to serialize the option                                                                        |
 | `value`             | string                                                 |          | Selected option value                                                                                       |
 
-#### Types {Select-types}
+#### Types {#Select-types}
 
 ##### `SelectOptionType`
 
@@ -578,7 +578,7 @@ Props:
 | `style`     | <CSSProperties /> |                             | Component style   |
 | `wrap`      | `Flex.Wrap`       | `Flex.Wrap.NO_WRAP`         | Flexbox wrap      |
 
-#### Types {Flex-types}
+#### Types {#Flex-types}
 
 ##### `Flex.Child` {#FlexChild}
 
@@ -621,7 +621,7 @@ Props:
 | `title`         | ReactNode                 |                           | Notice title                                                                  |
 | `type`          | `FormNotice.Types`        | `FormNotice.Types.DANGER` | Notice type                                                                   |
 
-#### Types {FormNotice-types}
+#### Types {#FormNotice-types}
 
 ##### `ImageData` {#ImageData}
 
@@ -767,7 +767,7 @@ Subcomponents:
 | [`Modal.ModalHeader`](#ModalHeader)           | Contains the header    |
 | [`Modal.ModalRoot`](#ModalRoot)               | Root component         |
 
-#### Types {Modal-types}
+#### Types {#Modal-types}
 
 ##### `Modal.ModalCloseButton` {#ModalCloseButton}
 

--- a/docs/plugins/modules/index.md
+++ b/docs/plugins/modules/index.md
@@ -168,18 +168,18 @@ export function start() {
 
 ## Processing modules
 
-### Get export for props {#getExportForProps}
+### Get exports for props {#getExportsForProps}
 
 When using `filters.byProps`, the actual properties you need may be nested under a random key. To
-get the actual export, you can use `getExportForProps`.
+get the actual export, you can use `getExportsForProps`.
 
 ```ts
 import { webpack } from "replugged";
-const { filters, getExportForProps, waitForModule } = webpack;
+const { filters, getExportsForProps, waitForModule } = webpack;
 
 export async function start() {
   const typingModuleRaw = await waitForModule(filters.byProps("getChannelId", "addChangeListener"));
-  const typingModule = getExportForProps(typingModuleRaw, ["getChannelId", "addChangeListener"]);
+  const typingModule = getExportsForProps(typingModuleRaw, ["getChannelId", "addChangeListener"]);
 }
 ```
 


### PR DESCRIPTION
Fixed components Types heading IDs, `Messages` -> `Message` in i18n common modules and `getExportForProps` -> `getExportsForProps` in webpack modules page.